### PR TITLE
Thumbnail previews from vtt file can be overwritten

### DIFF
--- a/vast.js
+++ b/vast.js
@@ -1478,7 +1478,7 @@ var fluidPlayerClass = {
                                 result.push({
                                     startTime: vttRawData.cues[i].startTime,
                                     endTime: vttRawData.cues[i].endTime,
-                                    image: tempThumbnailData[0],
+                                    image: (player.displayOptions.timelinePreview.sprite ? player.displayOptions.timelinePreview.sprite : tempThumbnailData[0]),
                                     x: parseInt(tempThumbnailCoordinates[0]),
                                     y: parseInt(tempThumbnailCoordinates[1]),
                                     w: parseInt(tempThumbnailCoordinates[2]),
@@ -1672,7 +1672,7 @@ var fluidPlayerClass = {
             templateLocation:         fluidPlayerScriptLocation + 'templates/', //Custom folder where the template is located
             scriptsLocation:          fluidPlayerScriptLocation + 'scripts/', //Custom folder where additional scripts are located
             vastTimeout:              5000, //number of milliseconds before the VAST Tag call timeouts
-            timelinePreview:          {}, //Structure: {file: 'filename.vtt', type: 'VTT'}. Supported types: VTT only at this time.
+            timelinePreview:          {}, //Structure: {file: 'filename.vtt', sprite: 'timeline.jpg', type: 'VTT'}. Supported types: VTT only at this time. Sprite will override values from vtt file
             vastLoadedCallback:       (function() {}),
             noVastVideoCallback:      (function() {}),
             vastVideoSkippedCallback: (function() {}),


### PR DESCRIPTION
In case if vtt file refer to thumbnail file that uses token protection it's url can be overwritten:
```
var testVideo = fluidPlayer(
    'my-video',
    'http://example.com/vast.xml',
    {
        timelinePreview: {
            file: 'thumbnails.vtt',
            sprite: 'thumbnails.jpg?expires=1480367616&token=d44016bd87026f86b10d66501aadd47a',
            type: 'VTT'
        }
    }
);
```