### PR TITLE
Update fluidplayer.js to support double click for fullscreen

### DIFF
--- a/fluidplayer.js
+++ b/fluidplayer.js
@@ -3284,6 +3284,10 @@ var fluidPlayerClass = {
             player.playPauseToggle(videoPlayerTag);
         }, false);
 
+        document.getElementById(this.videoPlayerId).addEventListener('dblclick', function() {
+            player.fullscreenToggle();
+        }, false);
+
         switch (this.displayOptions.layoutControls.layout) {
             case 'browser':
                 //Nothing special to do here at this point.


### PR DESCRIPTION
Basic support for go to fullscreen if player double clicked.
It works for desktop.