### PR TITLE
Static thumbnail configuration

### DIFF
--- a/src/modules/timeline.js
+++ b/src/modules/timeline.js
@@ -193,12 +193,10 @@ export default function (playerInstance, options) {
                 window.WebVTTParser = it.default;
                 playerInstance.setupThumbnailPreviewVtt();
             });
-        }
-        else if ('static' === timelinePreview.type && typeof timelinePreview.frames === 'object') {
+        } else if ('static' === timelinePreview.type && typeof timelinePreview.frames === 'object') {
             timelinePreview.spriteImage = true;
             playerInstance.timelinePreviewData = timelinePreview.frames;
-        }
-        else {
+        } else {
             throw 'Invalid thumbnail-preview - type must be VTT or static';
         }
 

--- a/src/modules/timeline.js
+++ b/src/modules/timeline.js
@@ -163,42 +163,45 @@ export default function (playerInstance, options) {
     };
 
     playerInstance.setupThumbnailPreview = () => {
-        const timelinePreview = playerInstance.displayOptions.layoutControls.timelinePreview;
-        if (timelinePreview &&
-            ((timelinePreview.type === 'VTT' && typeof timelinePreview.file === 'string') ||
-             (timelinePreview.type === 'static' && typeof timelinePreview.frames === 'object')) ) {
-            let eventOn = 'mousemove';
-            let eventOff = 'mouseleave';
-            if (playerInstance.mobileInfo.userOs) {
-                eventOn = 'touchmove';
-                eventOff = 'touchend';
-            }
-            document.getElementById(playerInstance.videoPlayerId + '_fluid_controls_progress_container')
-                .addEventListener(eventOn, playerInstance.drawTimelinePreview.bind(playerInstance), false);
-            document.getElementById(playerInstance.videoPlayerId + '_fluid_controls_progress_container')
-                .addEventListener(eventOff, function (event) {
-                    const progress = document.getElementById(playerInstance.videoPlayerId + '_fluid_controls_progress_container');
-                    if (typeof event.clientX !== 'undefined' && progress.contains(document.elementFromPoint(event.clientX, event.clientY))) {
-                        //False positive (Chrome bug when fast click causes leave event)
-                        return;
-                    }
-                    document.getElementById(playerInstance.videoPlayerId + '_fluid_timeline_preview_container').style.display = 'none';
-                    document.getElementById(playerInstance.videoPlayerId + '_fluid_timeline_preview_container_shadow').style.display = 'none';
-                }, false);
-            playerInstance.generateTimelinePreviewTags();
-
-            if (timelinePreview.type === 'VTT') {
-                import(/* webpackChunkName: "webvtt" */ '../../vendor/webvtt').then((it) => {
-                    window.WebVTTParser = it.default;
-                    playerInstance.setupThumbnailPreviewVtt();
-                });
-            }
-            else {
-                playerInstance.displayOptions.layoutControls.timelinePreview.spriteImage = true;
-                playerInstance.timelinePreviewData = timelinePreview.frames;
-            }
-
-            playerInstance.showTimeOnHover = false;
+        let timelinePreview = playerInstance.displayOptions.layoutControls.timelinePreview;
+        if (!timelinePreview || !timelinePreview.type) {
+            return;
         }
+
+        let eventOn = 'mousemove';
+        let eventOff = 'mouseleave';
+        if (playerInstance.mobileInfo.userOs) {
+            eventOn = 'touchmove';
+            eventOff = 'touchend';
+        }
+        document.getElementById(playerInstance.videoPlayerId + '_fluid_controls_progress_container')
+            .addEventListener(eventOn, playerInstance.drawTimelinePreview.bind(playerInstance), false);
+        document.getElementById(playerInstance.videoPlayerId + '_fluid_controls_progress_container')
+            .addEventListener(eventOff, function (event) {
+                const progress = document.getElementById(playerInstance.videoPlayerId + '_fluid_controls_progress_container');
+                if (typeof event.clientX !== 'undefined' && progress.contains(document.elementFromPoint(event.clientX, event.clientY))) {
+                    //False positive (Chrome bug when fast click causes leave event)
+                    return;
+                }
+                document.getElementById(playerInstance.videoPlayerId + '_fluid_timeline_preview_container').style.display = 'none';
+                document.getElementById(playerInstance.videoPlayerId + '_fluid_timeline_preview_container_shadow').style.display = 'none';
+            }, false);
+        playerInstance.generateTimelinePreviewTags();
+
+        if ('VTT' === timelinePreview.type && typeof timelinePreview.file === 'string') {
+            import(/* webpackChunkName: "webvtt" */ '../../vendor/webvtt').then((it) => {
+                window.WebVTTParser = it.default;
+                playerInstance.setupThumbnailPreviewVtt();
+            });
+        }
+        else if ('static' === timelinePreview.type && typeof timelinePreview.frames === 'object') {
+            timelinePreview.spriteImage = true;
+            playerInstance.timelinePreviewData = timelinePreview.frames;
+        }
+        else {
+            throw 'Invalid thumbnail-preview - type target must be VTT or static';
+        }
+
+        playerInstance.showTimeOnHover = false;
     };
 }

--- a/src/modules/timeline.js
+++ b/src/modules/timeline.js
@@ -199,7 +199,7 @@ export default function (playerInstance, options) {
             playerInstance.timelinePreviewData = timelinePreview.frames;
         }
         else {
-            throw 'Invalid thumbnail-preview - type target must be VTT or static';
+            throw 'Invalid thumbnail-preview - type must be VTT or static';
         }
 
         playerInstance.showTimeOnHover = false;

--- a/test/html/vod_basic_vtt_static.tpl.html
+++ b/test/html/vod_basic_vtt_static.tpl.html
@@ -1,0 +1,1857 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>VOD with static-thumbnails</title>
+    <%= htmlWebpackPlugin.tags.headTags %>
+    <style lang="css">
+        #fluid-player-e2e-case {
+            width: 90%;
+        }
+    </style>
+</head>
+<body>
+
+<video id="fluid-player-e2e-case">
+    <source src='https://cdn.fluidplayer.com/videos/valerian-1080p.mkv' data-fluid-hd title="1080p" type='video/mp4'/>
+    <source src='https://cdn.fluidplayer.com/videos/valerian-720p.mkv' data-fluid-hd title="720p" type='video/mp4'/>
+    <source src='https://cdn.fluidplayer.com/videos/valerian-480p.mkv' title="480p" type='video/mp4'/>
+</video>
+
+<%= htmlWebpackPlugin.tags.bodyTags %>
+
+<script>
+    var instance = fluidPlayer('fluid-player-e2e-case', {
+        layoutControls: {
+            timelinePreview: {
+                type: 'static',
+                frames: [
+                    {
+                        startTime: 0,
+                        endTime: 0.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 0,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 0.5,
+                        endTime: 1,
+                        image: '/static/thumbnails.jpg',
+                        x: 200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 1,
+                        endTime: 1.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 1.5,
+                        endTime: 2,
+                        image: '/static/thumbnails.jpg',
+                        x: 600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 2,
+                        endTime: 2.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 2.5,
+                        endTime: 3,
+                        image: '/static/thumbnails.jpg',
+                        x: 1000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 3,
+                        endTime: 3.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 1200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 3.5,
+                        endTime: 4,
+                        image: '/static/thumbnails.jpg',
+                        x: 1400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 4,
+                        endTime: 4.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 1600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 4.5,
+                        endTime: 5,
+                        image: '/static/thumbnails.jpg',
+                        x: 1800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 5,
+                        endTime: 5.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 2000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 5.5,
+                        endTime: 6,
+                        image: '/static/thumbnails.jpg',
+                        x: 2200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 6,
+                        endTime: 6.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 2400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 6.5,
+                        endTime: 7,
+                        image: '/static/thumbnails.jpg',
+                        x: 2600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 7,
+                        endTime: 7.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 2800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 7.5,
+                        endTime: 8,
+                        image: '/static/thumbnails.jpg',
+                        x: 3000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 8,
+                        endTime: 8.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 3200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 8.5,
+                        endTime: 9,
+                        image: '/static/thumbnails.jpg',
+                        x: 3400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 9,
+                        endTime: 9.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 3600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 9.5,
+                        endTime: 10,
+                        image: '/static/thumbnails.jpg',
+                        x: 3800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 10,
+                        endTime: 10.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 4000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 10.5,
+                        endTime: 11,
+                        image: '/static/thumbnails.jpg',
+                        x: 4200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 11,
+                        endTime: 11.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 4400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 11.5,
+                        endTime: 12,
+                        image: '/static/thumbnails.jpg',
+                        x: 4600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 12,
+                        endTime: 12.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 4800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 12.5,
+                        endTime: 13,
+                        image: '/static/thumbnails.jpg',
+                        x: 5000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 13,
+                        endTime: 13.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 5200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 13.5,
+                        endTime: 14,
+                        image: '/static/thumbnails.jpg',
+                        x: 5400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 14,
+                        endTime: 14.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 5600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 14.5,
+                        endTime: 15,
+                        image: '/static/thumbnails.jpg',
+                        x: 5800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 15,
+                        endTime: 15.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 6000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 15.5,
+                        endTime: 16,
+                        image: '/static/thumbnails.jpg',
+                        x: 6200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 16,
+                        endTime: 16.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 6400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 16.5,
+                        endTime: 17,
+                        image: '/static/thumbnails.jpg',
+                        x: 6600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 17,
+                        endTime: 17.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 6800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 17.5,
+                        endTime: 18,
+                        image: '/static/thumbnails.jpg',
+                        x: 7000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 18,
+                        endTime: 18.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 7200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 18.5,
+                        endTime: 19,
+                        image: '/static/thumbnails.jpg',
+                        x: 7400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 19,
+                        endTime: 19.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 7600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 19.5,
+                        endTime: 20,
+                        image: '/static/thumbnails.jpg',
+                        x: 7800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 20,
+                        endTime: 20.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 8000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 20.5,
+                        endTime: 21,
+                        image: '/static/thumbnails.jpg',
+                        x: 8200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 21,
+                        endTime: 21.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 8400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 21.5,
+                        endTime: 22,
+                        image: '/static/thumbnails.jpg',
+                        x: 8600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 22,
+                        endTime: 22.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 8800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 22.5,
+                        endTime: 23,
+                        image: '/static/thumbnails.jpg',
+                        x: 9000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 23,
+                        endTime: 23.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 9200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 23.5,
+                        endTime: 24,
+                        image: '/static/thumbnails.jpg',
+                        x: 9400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 24,
+                        endTime: 24.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 9600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 24.5,
+                        endTime: 25,
+                        image: '/static/thumbnails.jpg',
+                        x: 9800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 25,
+                        endTime: 25.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 10000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 25.5,
+                        endTime: 26,
+                        image: '/static/thumbnails.jpg',
+                        x: 10200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 26,
+                        endTime: 26.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 10400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 26.5,
+                        endTime: 27,
+                        image: '/static/thumbnails.jpg',
+                        x: 10600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 27,
+                        endTime: 27.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 10800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 27.5,
+                        endTime: 28,
+                        image: '/static/thumbnails.jpg',
+                        x: 11000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 28,
+                        endTime: 28.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 11200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 28.5,
+                        endTime: 29,
+                        image: '/static/thumbnails.jpg',
+                        x: 11400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 29,
+                        endTime: 29.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 11600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 29.5,
+                        endTime: 30,
+                        image: '/static/thumbnails.jpg',
+                        x: 11800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 30,
+                        endTime: 30.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 12000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 30.5,
+                        endTime: 31,
+                        image: '/static/thumbnails.jpg',
+                        x: 12200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 31,
+                        endTime: 31.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 12400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 31.5,
+                        endTime: 32,
+                        image: '/static/thumbnails.jpg',
+                        x: 12600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 32,
+                        endTime: 32.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 12800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 32.5,
+                        endTime: 33,
+                        image: '/static/thumbnails.jpg',
+                        x: 13000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 33,
+                        endTime: 33.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 13200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 33.5,
+                        endTime: 34,
+                        image: '/static/thumbnails.jpg',
+                        x: 13400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 34,
+                        endTime: 34.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 13600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 34.5,
+                        endTime: 35,
+                        image: '/static/thumbnails.jpg',
+                        x: 13800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 35,
+                        endTime: 35.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 14000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 35.5,
+                        endTime: 36,
+                        image: '/static/thumbnails.jpg',
+                        x: 14200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 36,
+                        endTime: 36.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 14400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 36.5,
+                        endTime: 37,
+                        image: '/static/thumbnails.jpg',
+                        x: 14600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 37,
+                        endTime: 37.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 14800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 37.5,
+                        endTime: 38,
+                        image: '/static/thumbnails.jpg',
+                        x: 15000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 38,
+                        endTime: 38.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 15200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 38.5,
+                        endTime: 39,
+                        image: '/static/thumbnails.jpg',
+                        x: 15400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 39,
+                        endTime: 39.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 15600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 39.5,
+                        endTime: 40,
+                        image: '/static/thumbnails.jpg',
+                        x: 15800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 40,
+                        endTime: 40.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 16000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 40.5,
+                        endTime: 41,
+                        image: '/static/thumbnails.jpg',
+                        x: 16200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 41,
+                        endTime: 41.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 16400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 41.5,
+                        endTime: 42,
+                        image: '/static/thumbnails.jpg',
+                        x: 16600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 42,
+                        endTime: 42.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 16800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 42.5,
+                        endTime: 43,
+                        image: '/static/thumbnails.jpg',
+                        x: 17000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 43,
+                        endTime: 43.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 17200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 43.5,
+                        endTime: 44,
+                        image: '/static/thumbnails.jpg',
+                        x: 17400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 44,
+                        endTime: 44.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 17600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 44.5,
+                        endTime: 45,
+                        image: '/static/thumbnails.jpg',
+                        x: 17800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 45,
+                        endTime: 45.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 18000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 45.5,
+                        endTime: 46,
+                        image: '/static/thumbnails.jpg',
+                        x: 18200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 46,
+                        endTime: 46.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 18400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 46.5,
+                        endTime: 47,
+                        image: '/static/thumbnails.jpg',
+                        x: 18600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 47,
+                        endTime: 47.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 18800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 47.5,
+                        endTime: 48,
+                        image: '/static/thumbnails.jpg',
+                        x: 19000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 48,
+                        endTime: 48.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 19200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 48.5,
+                        endTime: 49,
+                        image: '/static/thumbnails.jpg',
+                        x: 19400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 49,
+                        endTime: 49.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 19600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 49.5,
+                        endTime: 50,
+                        image: '/static/thumbnails.jpg',
+                        x: 19800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 50,
+                        endTime: 50.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 20000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 50.5,
+                        endTime: 51,
+                        image: '/static/thumbnails.jpg',
+                        x: 20200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 51,
+                        endTime: 51.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 20400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 51.5,
+                        endTime: 52,
+                        image: '/static/thumbnails.jpg',
+                        x: 20600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 52,
+                        endTime: 52.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 20800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 52.5,
+                        endTime: 53,
+                        image: '/static/thumbnails.jpg',
+                        x: 21000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 53,
+                        endTime: 53.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 21200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 53.5,
+                        endTime: 54,
+                        image: '/static/thumbnails.jpg',
+                        x: 21400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 54,
+                        endTime: 54.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 21600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 54.5,
+                        endTime: 55,
+                        image: '/static/thumbnails.jpg',
+                        x: 21800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 55,
+                        endTime: 55.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 22000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 55.5,
+                        endTime: 56,
+                        image: '/static/thumbnails.jpg',
+                        x: 22200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 56,
+                        endTime: 56.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 22400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 56.5,
+                        endTime: 57,
+                        image: '/static/thumbnails.jpg',
+                        x: 22600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 57,
+                        endTime: 57.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 22800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 57.5,
+                        endTime: 58,
+                        image: '/static/thumbnails.jpg',
+                        x: 23000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 58,
+                        endTime: 58.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 23200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 58.5,
+                        endTime: 59,
+                        image: '/static/thumbnails.jpg',
+                        x: 23400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 59,
+                        endTime: 59.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 23600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 59.5,
+                        endTime: 60,
+                        image: '/static/thumbnails.jpg',
+                        x: 23800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 60,
+                        endTime: 60.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 24000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 60.5,
+                        endTime: 61,
+                        image: '/static/thumbnails.jpg',
+                        x: 24200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 61,
+                        endTime: 61.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 24400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 61.5,
+                        endTime: 62,
+                        image: '/static/thumbnails.jpg',
+                        x: 24600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 62,
+                        endTime: 62.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 24800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 62.5,
+                        endTime: 63,
+                        image: '/static/thumbnails.jpg',
+                        x: 25000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 63,
+                        endTime: 63.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 25200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 63.5,
+                        endTime: 64,
+                        image: '/static/thumbnails.jpg',
+                        x: 25400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 64,
+                        endTime: 64.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 25600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 64.5,
+                        endTime: 65,
+                        image: '/static/thumbnails.jpg',
+                        x: 25800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 65,
+                        endTime: 65.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 26000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 65.5,
+                        endTime: 66,
+                        image: '/static/thumbnails.jpg',
+                        x: 26200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 66,
+                        endTime: 66.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 26400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 66.5,
+                        endTime: 67,
+                        image: '/static/thumbnails.jpg',
+                        x: 26600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 67,
+                        endTime: 67.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 26800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 67.5,
+                        endTime: 68,
+                        image: '/static/thumbnails.jpg',
+                        x: 27000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 68,
+                        endTime: 68.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 27200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 68.5,
+                        endTime: 69,
+                        image: '/static/thumbnails.jpg',
+                        x: 27400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 69,
+                        endTime: 69.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 27600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 69.5,
+                        endTime: 70,
+                        image: '/static/thumbnails.jpg',
+                        x: 27800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 70,
+                        endTime: 70.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 28000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 70.5,
+                        endTime: 70,
+                        image: '/static/thumbnails.jpg',
+                        x: 28200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 71,
+                        endTime: 71.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 28400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 71.5,
+                        endTime: 72,
+                        image: '/static/thumbnails.jpg',
+                        x: 28600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 72,
+                        endTime: 72.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 28800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 72.5,
+                        endTime: 73,
+                        image: '/static/thumbnails.jpg',
+                        x: 29000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 73,
+                        endTime: 73.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 29200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 73.5,
+                        endTime: 74,
+                        image: '/static/thumbnails.jpg',
+                        x: 29400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 74,
+                        endTime: 74.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 29600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 74.5,
+                        endTime: 75,
+                        image: '/static/thumbnails.jpg',
+                        x: 29800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 75,
+                        endTime: 75.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 30000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 75.5,
+                        endTime: 76,
+                        image: '/static/thumbnails.jpg',
+                        x: 30200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 76,
+                        endTime: 76.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 30400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 76.5,
+                        endTime: 77,
+                        image: '/static/thumbnails.jpg',
+                        x: 30600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 77,
+                        endTime: 77.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 30800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 77.5,
+                        endTime: 78,
+                        image: '/static/thumbnails.jpg',
+                        x: 31000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 78,
+                        endTime: 78.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 31200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 78.5,
+                        endTime: 79,
+                        image: '/static/thumbnails.jpg',
+                        x: 31400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 79,
+                        endTime: 79.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 31600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 79.5,
+                        endTime: 80,
+                        image: '/static/thumbnails.jpg',
+                        x: 31800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 80,
+                        endTime: 80.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 32000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 80.5,
+                        endTime: 81,
+                        image: '/static/thumbnails.jpg',
+                        x: 32200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 81,
+                        endTime: 81.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 32400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 81.5,
+                        endTime: 82,
+                        image: '/static/thumbnails.jpg',
+                        x: 32600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 82,
+                        endTime: 82.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 32800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 82.5,
+                        endTime: 83,
+                        image: '/static/thumbnails.jpg',
+                        x: 33000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 83,
+                        endTime: 83.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 33200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 83.5,
+                        endTime: 84,
+                        image: '/static/thumbnails.jpg',
+                        x: 33400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 84,
+                        endTime: 84.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 33600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 84.5,
+                        endTime: 85,
+                        image: '/static/thumbnails.jpg',
+                        x: 33800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 85,
+                        endTime: 85.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 34000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 85.5,
+                        endTime: 86,
+                        image: '/static/thumbnails.jpg',
+                        x: 34200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 86,
+                        endTime: 86.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 34400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 86.5,
+                        endTime: 87,
+                        image: '/static/thumbnails.jpg',
+                        x: 34600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 87,
+                        endTime: 87.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 34800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 87.5,
+                        endTime: 88,
+                        image: '/static/thumbnails.jpg',
+                        x: 35000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 88,
+                        endTime: 88.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 35200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 88.5,
+                        endTime: 89,
+                        image: '/static/thumbnails.jpg',
+                        x: 35400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 89,
+                        endTime: 89.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 35600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 89.5,
+                        endTime: 90,
+                        image: '/static/thumbnails.jpg',
+                        x: 35800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 90,
+                        endTime: 90.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 36000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 90.5,
+                        endTime: 91,
+                        image: '/static/thumbnails.jpg',
+                        x: 36200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 91,
+                        endTime: 91.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 36400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 91.5,
+                        endTime: 92,
+                        image: '/static/thumbnails.jpg',
+                        x: 36600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 92,
+                        endTime: 92.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 36800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 92.5,
+                        endTime: 93,
+                        image: '/static/thumbnails.jpg',
+                        x: 37000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 93,
+                        endTime: 93.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 37200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 93.5,
+                        endTime: 94,
+                        image: '/static/thumbnails.jpg',
+                        x: 37400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 94,
+                        endTime: 94.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 37600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 94.5,
+                        endTime: 95,
+                        image: '/static/thumbnails.jpg',
+                        x: 37800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 95,
+                        endTime: 95.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 38000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 95.5,
+                        endTime: 96,
+                        image: '/static/thumbnails.jpg',
+                        x: 38200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 96,
+                        endTime: 96.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 38400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 96.5,
+                        endTime: 97,
+                        image: '/static/thumbnails.jpg',
+                        x: 38600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 97,
+                        endTime: 97.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 38800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 97.5,
+                        endTime: 98,
+                        image: '/static/thumbnails.jpg',
+                        x: 39000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 98,
+                        endTime: 98.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 39200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 98.5,
+                        endTime: 99,
+                        image: '/static/thumbnails.jpg',
+                        x: 39400,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 99,
+                        endTime: 99.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 39600,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 99.5,
+                        endTime: 100,
+                        image: '/static/thumbnails.jpg',
+                        x: 39800,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 100,
+                        endTime: 100.5,
+                        image: '/static/thumbnails.jpg',
+                        x: 40000,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                    {
+                        startTime: 100.5,
+                        endTime: 101,
+                        image: '/static/thumbnails.jpg',
+                        x: 40200,
+                        y: 0,
+                        w: 200,
+                        h: 84
+                    },
+                ]
+            }
+        },
+    });
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
Fixes: #448
Testcase: http://doppelbauer.name/fluidplayer/

The patch bypasses `playerInstance.setupThumbnailPreviewVtt()` and fills `playerInstance.timelinePreviewData` from configuration.