### PR TITLE
Mobile optimalization

### DIFF
--- a/src/modules/timeline.js
+++ b/src/modules/timeline.js
@@ -134,6 +134,10 @@ export default function (playerInstance, options) {
 
         //get the hover position
         const hoverX = playerInstance.getEventOffsetX(event, progressContainer);
+        const clamp = (a, b, c) => {
+            return Math.max(b,Math.min(c,a));
+        };
+
         let hoverSecond = null;
 
         if (totalWidth) {
@@ -150,7 +154,11 @@ export default function (playerInstance, options) {
                 timelinePreviewShadow.style.height = thumbnailCoordinates.h + 'px';
                 timelinePreviewTag.style.background =
                     'url(' + thumbnailCoordinates.image + ') no-repeat scroll -' + thumbnailCoordinates.x + 'px -' + thumbnailCoordinates.y + 'px';
-                timelinePreviewTag.style.left = hoverX - (thumbnailCoordinates.w / 2) + 'px';
+
+                const left = hoverX - thumbnailCoordinates.w / 2 - 3;
+                const leftClamped = clamp(left, 0, totalWidth - thumbnailCoordinates.w);
+
+                timelinePreviewTag.style.left = leftClamped + 'px';
                 timelinePreviewTag.style.display = 'block';
                 if (!playerInstance.displayOptions.layoutControls.timelinePreview.spriteImage) {
                     timelinePreviewTag.style.backgroundSize = 'contain';


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

I optimized the case mentioned in issue #496. Also, I changed the calculation of thumbnail position which is now clamped inside player. This PR should be heavily tested on different devices.

## Proposed Changes

1. On mobile devices, touch events should not skip video on the background (if thumbnail previews are enabled)
2. Previews are clamped into player view, no overflowing from player element

## Relevant issues

Closes #496