### PR TITLE
FP-133 - Fluidplayer_(GitHub-530)_contextMenu.links labels are not working after play

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,19 @@ node_modules/
 dist/
 dist-cdn/
 e2e/
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json

--- a/src/fluidplayer.js
+++ b/src/fluidplayer.js
@@ -1739,13 +1739,13 @@ const fluidPlayerClass = function () {
         divContextMenu.appendChild(contextMenuList);
 
         if (!!extraLinks) {
-            for (const link of extraLinks) {
+            extraLinks.forEach(function appendExtraLinks(link, index) {
                 const linkItem = document.createElement('li');
-                linkItem.id = self.videoPlayerId + 'context_option_play';
+                linkItem.id = self.videoPlayerId + '_extra_link_' + index;
                 linkItem.innerHTML = link.label;
                 linkItem.addEventListener('click', () => window.open(link.href, '_blank'), false);
                 contextMenuList.appendChild(linkItem);
-            }
+            });
         }
 
         if (showDefaultControls) {

--- a/src/fluidplayer.js
+++ b/src/fluidplayer.js
@@ -1738,7 +1738,7 @@ const fluidPlayerClass = function () {
         const contextMenuList = document.createElement('ul');
         divContextMenu.appendChild(contextMenuList);
 
-        if (!!extraLinks) {
+        if (Array.isArray(extraLinks)) {
             extraLinks.forEach(function appendExtraLinks(link, index) {
                 const linkItem = document.createElement('li');
                 linkItem.id = self.videoPlayerId + '_extra_link_' + index;


### PR DESCRIPTION
The extra links were being generated with the same ID as the context menu play button, this PR adds custom IDs for the extra links.

Fixes #530