### PR TITLE
Fix for vertical VAST videos

### DIFF
--- a/src/modules/adsupport.js
+++ b/src/modules/adsupport.js
@@ -1544,9 +1544,7 @@ export default function (playerInstance, options) {
         divClickThrough.id = 'vast_clickthrough_layer_' + playerInstance.videoPlayerId;
         divClickThrough.setAttribute(
             'style',
-            'position: absolute; cursor: pointer; top: 0; left: 0; width: ' +
-            playerInstance.domRef.player.offsetWidth + 'px; height: ' +
-            (playerInstance.domRef.player.offsetHeight) + 'px;'
+            'position: absolute; cursor: pointer; top: 0; left: 0; bottom:0;'
         );
 
         divWrapper.appendChild(divClickThrough);


### PR DESCRIPTION
To reproduce bug:
Setup horizontal video 640x360
Load vertical vast video 640x640 (for example).
Only top half of video have ad click trigger
