### PR TITLE
Fix calling Impression for wrapper chain (#777)

### DIFF
--- a/src/modules/vast.js
+++ b/src/modules/vast.js
@@ -763,7 +763,7 @@ export default function (playerInstance, options) {
      */
     function flattenAdTree(root, ads = [], wrappers = []) {
         if (Array.isArray(root.children) && root.children.length) {
-            root.children.forEach(child => flattenAdTree(child, ads, [...root.wrappers || [], root.data]))
+            root.children.forEach(child => flattenAdTree(child, ads, [...wrappers || [], root.data]))
         }
 
         if (root.tagType === 'inLine') {

--- a/test/html/special-cases/issue-777.tpl.html
+++ b/test/html/special-cases/issue-777.tpl.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>VOD with nested VAST Wrapper</title>
+    <%= htmlWebpackPlugin.tags.headTags %>
+    <style lang="css">
+        #fluid-player-e2e-case {
+            width: 90%;
+        }
+    </style>
+</head>
+<body>
+
+<video id="fluid-player-e2e-case">
+    <source src="https://cdn.fluidplayer.com/videos/valerian-1080p.mkv" data-fluid-hd title="1080p" type="video/mp4"/>
+    <source src="https://cdn.fluidplayer.com/videos/valerian-720p.mkv" data-fluid-hd title="720p" type="video/mp4"/>
+    <source src="https://cdn.fluidplayer.com/videos/valerian-480p.mkv" title="480p" type="video/mp4"/>
+</video>
+
+<%= htmlWebpackPlugin.tags.bodyTags %>
+
+<script>
+    var instance = fluidPlayer('fluid-player-e2e-case', {
+        vastOptions: {
+            allowVPAID: true,
+            adList: [
+                {
+                    roll: 'preRoll',
+                    vastTag: '/static/special-cases/issue-777.xml',
+                },
+            ]
+        }
+    });
+</script>
+
+</body>
+</html>

--- a/test/static/special-cases/issue-777.xml
+++ b/test/static/special-cases/issue-777.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<VAST xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../vast4.xsd" version="4.2">
+    <Ad id="123456">
+        <Wrapper>
+            <AdSystem>Ad System</AdSystem>
+            <VASTAdTagURI><![CDATA[https://elixircasts.ru/fluidplayer-bug/wrapper.xml]]></VASTAdTagURI>
+            <Impression><![CDATA[/nesting_wrapper_impression]]></Impression>
+            <Error><![CDATA[/nested_wrapper_error]]></Error>
+            <Creatives>
+                <Creative>
+                    <Linear>
+                        <TrackingEvents>
+                            <Tracking event="progress" offset="00:00:10.000"><![CDATA[/nesting_wrapper_progress]]></Tracking>
+                        </TrackingEvents>
+                        <VideoClicks>
+                            <ClickTracking><![CDATA[/nesting_wrapper_click]]></ClickTracking>
+                        </VideoClicks>
+                    </Linear>
+                </Creative>
+            </Creatives>
+        </Wrapper>
+    </Ad>
+</VAST>


### PR DESCRIPTION
This is a possible fix for https://github.com/fluid-player/fluid-player/issues/777

I do not have a deep understanding of VAST protocol and Fluidplayer's implementation of it, so feel free to critisize/reject.

## Proposed Changes

Keep wrappers for each call of `flattenAdTree` to be able to call `<Impressions>` for the whole chain when the ad is started.

## Relevant issues

Closes #777
