### PR TITLE
fix: prevent skip-forward/back icons from getting stuck visible

### DIFF
--- a/e2e/skip_stuck.spec.ts
+++ b/e2e/skip_stuck.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Regression test for the skip-forward / skip-backward animation icons
+ * getting stuck visible when arrow keys are mashed during video buffering.
+ *
+ * Root cause: skipRelative() adds the `.animate` class and relies on a
+ * transitionend event to remove it. Under main-thread pressure (rapid
+ * seeking that forces buffering), the browser can drop transition events
+ * and the class never gets removed, leaving the +10s / -10s icon
+ * permanently visible on the player.
+ */
+test.describe('skip animation icons', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/skip_return.html');
+        // Click the player to start playback AND install the document-level
+        // keyboard handler (captureKey is bound on first wrapper click).
+        await page.locator('#fluid_video_wrapper_fluid-player-e2e-case').click();
+        await page.waitForFunction(() => {
+            const v = document.querySelector('video');
+            return v && !v.paused && v.readyState >= 2;
+        });
+    });
+
+    test('icons do not get stuck when alternating arrow keys rapidly', async ({ page }) => {
+        // Seek near the end so each skip bounces around an unbuffered region,
+        // creating the main-thread pressure that surfaces the bug.
+        await page.evaluate(() => {
+            const v = document.querySelector('video')!;
+            v.currentTime = Math.max(0, (v.duration || 60) - 30);
+        });
+
+        // Try the alternation pattern multiple times; the bug is racy so a
+        // single burst may not trigger pre-fix. After the fix, no burst
+        // should ever leave the class stuck.
+        for (let attempt = 0; attempt < 5; attempt++) {
+            for (let i = 0; i < 40; i++) {
+                await page.keyboard.press(i % 2 === 0 ? 'ArrowRight' : 'ArrowLeft');
+            }
+
+            // Give transitions time to settle: 150ms fade-in + 400ms fade-out + slack.
+            await page.waitForTimeout(1200);
+
+            const stuck = await page.evaluate(() => {
+                const f = document.querySelector('.fluid_player_skip_offset__forward-icon')!;
+                const b = document.querySelector('.fluid_player_skip_offset__backward-icon')!;
+                return {
+                    fwd:  { anim: f.classList.contains('animate'), op: getComputedStyle(f).opacity },
+                    back: { anim: b.classList.contains('animate'), op: getComputedStyle(b).opacity },
+                };
+            });
+
+            expect(stuck.fwd.anim,  `attempt ${attempt}: forward icon stuck`).toBe(false);
+            expect(stuck.back.anim, `attempt ${attempt}: backward icon stuck`).toBe(false);
+        }
+    });
+});

--- a/src/fluidplayer.js
+++ b/src/fluidplayer.js
@@ -2177,7 +2177,6 @@ const fluidPlayerClass = function () {
 
         const skipAnimationBackwardIcon = document.createElement('div');
         skipAnimationBackwardIcon.classList.add('fluid_player_skip_offset__backward-icon');
-        skipAnimationBackwardIcon.ontransitionend = () => skipAnimationBackwardIcon.classList.remove('animate');
         skipAnimationBackward.appendChild(skipAnimationBackwardIcon);
 
         const skipAnimationForward = document.createElement('div');
@@ -2186,7 +2185,6 @@ const fluidPlayerClass = function () {
 
         const skipAnimationForwardIcon = document.createElement('div');
         skipAnimationForwardIcon.classList.add('fluid_player_skip_offset__forward-icon');
-        skipAnimationForwardIcon.ontransitionend = () => skipAnimationForwardIcon.classList.remove('animate');
         skipAnimationForward.appendChild(skipAnimationForwardIcon);
 
         self.domRef.player.parentNode.insertBefore(skipAnimationWrapper, self.domRef.player.nextSibling);
@@ -2253,14 +2251,17 @@ const fluidPlayerClass = function () {
         }
         self.domRef.player.currentTime = skipTo;
 
-        // Trigger animation
-        if (timeOffset >= 0) {
-            const forwardElement = self.domRef.wrapper.querySelector(`.fluid_player_skip_offset__forward-icon`);
-            forwardElement.classList.add('animate');
-        } else {
-            const backwardElement = self.domRef.wrapper.querySelector(`.fluid_player_skip_offset__backward-icon`);
-            backwardElement.classList.add('animate');
-        }
+        // Trigger animation. Use a timer for cleanup instead of `transitionend`:
+        // under main-thread pressure (e.g. rapid seeking that forces buffering),
+        // the browser can drop transition events and the `.animate` class would
+        // never be removed, leaving the icon permanently visible.
+        const iconSelector = timeOffset >= 0
+            ? '.fluid_player_skip_offset__forward-icon'
+            : '.fluid_player_skip_offset__backward-icon';
+        const icon = self.domRef.wrapper.querySelector(iconSelector);
+        clearTimeout(icon._fadeTimer);
+        icon.classList.add('animate');
+        icon._fadeTimer = setTimeout(() => icon.classList.remove('animate'), 600);
     }
 
     /**


### PR DESCRIPTION
The skip animation icons used `ontransitionend` to remove the `.animate` class, but the browser can drop transition events when the main thread is under load (e.g. rapid seeking that forces buffering). When that happens the class is never removed and the `+10s` / `-10s` overlay stays permanently visible on the player.

Replace the `transitionend` handler with a `setTimeout`-based cleanup that is cleared and re-armed on each skip, and add a Playwright regression test that exercises rapid alternating arrow-key skips during buffering.

## Proposed Changes

1. **`src/fluidplayer.js`** — remove the two `ontransitionend = () => classList.remove('animate')` handlers on the forward and backward skip icons. They are unreliable: `transitionend` does not fire for interrupted transitions (the browser fires `transitioncancel` instead), can be dropped under main-thread pressure, and is not dispatched at all when the value delta is below the browser's coalescing threshold (e.g. `opacity: 0.99 → 1`).
2. **`src/fluidplayer.js`** — in `skipRelative()`, replace the bare `classList.add('animate')` with a per-icon `setTimeout` (600 ms, matching the 150 ms fade-in + 400 ms fade-out plus a small slack) that is cleared and re-armed on every call. This guarantees the class is removed regardless of how chaotic the transition sequence is, while still letting back-to-back skips extend the visible window naturally.
3. **`e2e/skip_stuck.spec.ts`** — new Playwright regression test. Loads the `skip_return` demo, seeks near the end of the video to force unbuffered-range seeks, then alternates `ArrowRight` / `ArrowLeft` 40 times per attempt across 5 attempts and asserts that neither icon retains the `.animate` class afterward. Fails deterministically against `master` on attempt 0; passes after the fix.

## Relevant issues

Closes #932
